### PR TITLE
New Database Hint Logic Support

### DIFF
--- a/app/packs/page.tsx
+++ b/app/packs/page.tsx
@@ -35,12 +35,12 @@ export default function PacksPage() {
                       #{nonogram.id}: {nonogram.title}
                     </CardTitle>
                     <CardDescription>
-                      {nonogram.rows} x {nonogram.columns}
+                      {nonogram.height} x {nonogram.width}
                     </CardDescription>
                   </CardHeader>
                   <NonogramGridPreview
-                    rows={nonogram.rows}
-                    columns={nonogram.columns}
+                    rows={nonogram.height}
+                    columns={nonogram.width}
                   ></NonogramGridPreview>
                   <CardFooter className="justify-center p-3">
                     <Link

--- a/app/packs/page.tsx
+++ b/app/packs/page.tsx
@@ -31,9 +31,7 @@ export default function PacksPage() {
               <li key={nonogram.id}>
                 <Card className="flex flex-col justify-between items-center bg-background p-2 h-[340px] w-[340px]">
                   <CardHeader className="p-3 justify-center text-center">
-                    <CardTitle>
-                      #{nonogram.id}: {nonogram.title}
-                    </CardTitle>
+                    <CardTitle>{nonogram.title}</CardTitle>
                     <CardDescription>
                       {nonogram.height} x {nonogram.width}
                     </CardDescription>
@@ -45,7 +43,7 @@ export default function PacksPage() {
                   <CardFooter className="justify-center p-3">
                     <Link
                       className={buttonVariants({ variant: "outline" })}
-                      href={`/nonogram?${nonogram.id}`}
+                      href={`/nonogram/${nonogram.id}`}
                     >
                       Play
                     </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
         <div className="flex gap-3 flex-col">
           <Link
             className={buttonVariants({ variant: "default", size: "lg" })}
-            href="/nonogram/2"
+            href="/nonogram/4"
           >
             Today&apos;s Puzzle
           </Link>

--- a/components/nonogram/grid.tsx
+++ b/components/nonogram/grid.tsx
@@ -36,7 +36,7 @@ export function Grid({
         solutionArray.slice(i * nonogram.height, (i + 1) * nonogram.height),
       );
       setMaxRowHints(Math.max(...rowHints.map((hint) => hint.length)));
-      setGrid(generateGrid(rows, rowHints, columnHints));
+      setGrid(generateGrid(nonogram, rowHints, columnHints));
     }
   }, [nonogram, rowHints, columnHints]);
 
@@ -148,7 +148,7 @@ export function Grid({
               : undefined
           }
         >
-          {item.type === GridItemType.Clue && item.clueValue}
+          {item.type === GridItemType.Clue && item.hintValue}
           {item.type === GridItemType.Cell && (
             <Cell cellState={item.cellState!} />
           )}

--- a/components/nonogram/nonogram.tsx
+++ b/components/nonogram/nonogram.tsx
@@ -3,15 +3,24 @@
 import React, { useEffect, useState } from "react";
 import { ControlPanel } from "@/components/nonogram/control-panel";
 import { Tables } from "@/types/database.types";
-import { getNonogram } from "@/lib/queries";
+import { getNonogram, getNonogramHints } from "@/lib/queries";
 import { Grid } from "@/components/nonogram/grid";
 
 export function Nonogram({ id }: { id: string }) {
   const [nonogram, setNonogram] = useState<Tables<"nonograms">>();
+  const [rowHints, setRowHints] = useState<number[][]>([]);
+  const [columnHints, setColumnHints] = useState<number[][]>([]);
   const [winConditionMet, setWinConditionMet] = useState(false);
 
   useEffect(() => {
     getNonogram(id).then((data) => setNonogram(data));
+    getNonogramHints(id).then(
+      (data) => {
+        setRowHints(data.rows);
+        setColumnHints(data.columns);
+      },
+      (error) => console.error(error),
+    );
   }, []);
 
   const onWinConditionMet = () => {
@@ -29,6 +38,8 @@ export function Nonogram({ id }: { id: string }) {
           <ControlPanel winConditionMet={winConditionMet}></ControlPanel>
           <Grid
             nonogram={nonogram}
+            rowHints={rowHints}
+            columnHints={columnHints}
             winConditionMet={winConditionMet}
             onWinConditionMet={onWinConditionMet}
           ></Grid>

--- a/lib/menu-items.tsx
+++ b/lib/menu-items.tsx
@@ -13,7 +13,7 @@ const menuItems: MenuItem[] = [
     label: "nonogram",
     name: "Today's Puzzle",
     icon: <Puzzle size={15} />,
-    url: "/nonogram/2",
+    url: "/nonogram/4",
   },
   {
     label: "packs",

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -34,3 +34,33 @@ export async function getAllNonograms(): Promise<Tables<"nonograms">[]> {
     return [];
   }
 }
+
+export async function getNonogramHints(
+  id: string,
+): Promise<{ rows: number[][]; columns: number[][] }> {
+  const supabase = createClient();
+  try {
+    const { data, error } = await supabase
+      .from("nonogram_hints")
+      .select("*")
+      .eq("puzzle_id", id);
+    if (error) {
+      throw new Error(error.message);
+      return { rows: [], columns: [] };
+    }
+    const rows = data
+      .filter((item) => item.direction === "row")
+      .sort((a, b) => a.index - b.index)
+      .map((item) => item.hints);
+
+    const columns = data
+      .filter((item) => item.direction === "column")
+      .sort((a, b) => a.index - b.index)
+      .map((item) => item.hints);
+
+    return { rows, columns };
+  } catch (error) {
+    console.error(error);
+    return { rows: [], columns: [] };
+  }
+}

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -4,58 +4,88 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   public: {
     Tables: {
+      nonogram_hints: {
+        Row: {
+          direction: string
+          hints: number[]
+          id: number
+          index: number
+          puzzle_id: number
+        }
+        Insert: {
+          direction: string
+          hints: number[]
+          id?: number
+          index: number
+          puzzle_id: number
+        }
+        Update: {
+          direction?: string
+          hints?: number[]
+          id?: number
+          index?: number
+          puzzle_id?: number
+        }
+        Relationships: []
+      }
       nonograms: {
         Row: {
-          author: string | null;
-          columns: number;
-          created_at: string | null;
-          id: number;
-          rows: number;
-          solution: string;
-          title: string;
-        };
+          author: string | null
+          copyright: string | null
+          created_at: string | null
+          height: number
+          id: number
+          license: string | null
+          solution: string
+          title: string
+          width: number
+        }
         Insert: {
-          author?: string | null;
-          columns: number;
-          created_at?: string | null;
-          id?: number;
-          rows: number;
-          solution: string;
-          title: string;
-        };
+          author?: string | null
+          copyright?: string | null
+          created_at?: string | null
+          height: number
+          id: number
+          license?: string | null
+          solution: string
+          title: string
+          width: number
+        }
         Update: {
-          author?: string | null;
-          columns?: number;
-          created_at?: string | null;
-          id?: number;
-          rows?: number;
-          solution?: string;
-          title?: string;
-        };
-        Relationships: [];
-      };
-    };
+          author?: string | null
+          copyright?: string | null
+          created_at?: string | null
+          height?: number
+          id?: number
+          license?: string | null
+          solution?: string
+          title?: string
+          width?: number
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      size: "5" | "10" | "15" | "20";
-    };
+      size: "5" | "10" | "15" | "20"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
   PublicTableNameOrOptions extends
@@ -68,7 +98,7 @@ export type Tables<
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
@@ -76,11 +106,11 @@ export type Tables<
         PublicSchema["Views"])
     ? (PublicSchema["Tables"] &
         PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-        Row: infer R;
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
@@ -91,17 +121,17 @@ export type TablesInsert<
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
     ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Insert: infer I;
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
@@ -112,17 +142,17 @@ export type TablesUpdate<
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
     ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Update: infer U;
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
@@ -135,14 +165,14 @@ export type Enums<
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-    : never;
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof PublicSchema["CompositeTypes"]
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof Database
   }
     ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
@@ -150,4 +180,4 @@ export type CompositeTypes<
   ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never;
+    : never

--- a/types/types.ts
+++ b/types/types.ts
@@ -23,6 +23,6 @@ export type GridItem = {
   type: GridItemType;
   rowIndex?: number;
   colIndex?: number;
-  clueValue?: number;
+  hintValue?: number;
   cellState?: CellState;
 };

--- a/utils/nonogram/generate-grid.ts
+++ b/utils/nonogram/generate-grid.ts
@@ -1,47 +1,58 @@
 import { CellState, GridItem, GridItemType } from "@/types/types";
+import { Tables } from "@/types/database.types";
 
 export const generateGrid = (
-  rows: number[][],
-  rowClues: number[][],
-  colClues: number[][],
+  nonogram: Tables<"nonograms">,
+  rowHints: number[][],
+  columnHints: number[][],
 ): GridItem[] => {
   const grid: GridItem[] = [];
-  const maxRowClues = Math.max(...rowClues.map((clue) => clue.length));
-  const maxColClues = Math.max(...colClues.map((clue) => clue.length));
+  const { width, height } = nonogram;
 
-  for (let r = 0; r < maxColClues; r++) {
-    for (let c = 0; c < maxRowClues; c++) {
-      grid.push({
-        type: GridItemType.Empty,
-      });
-    }
-    for (let c = 0; c < rows[0].length; c++) {
-      const clueValue = colClues[c][r - (maxColClues - colClues[c].length)];
-      grid.push(
-        clueValue !== undefined
-          ? { type: GridItemType.Clue, clueValue }
-          : { type: GridItemType.Empty },
-      );
-    }
-  }
+  const maxRowHints = Math.max(...rowHints.map((hint) => hint.length));
+  const maxColumnHints = Math.max(...columnHints.map((hint) => hint.length));
 
-  // Build the grid with row clues and cells
-  for (let r = 0; r < rows.length; r++) {
-    for (let c = 0; c < maxRowClues; c++) {
-      const clueValue = rowClues[r][c - (maxRowClues - rowClues[r].length)];
-      grid.push(
-        clueValue !== undefined
-          ? { type: GridItemType.Clue, clueValue }
-          : { type: GridItemType.Empty },
-      );
-    }
-    for (let c = 0; c < rows[r].length; c++) {
-      grid.push({
-        type: GridItemType.Cell,
-        rowIndex: r,
-        colIndex: c,
-        cellState: CellState.Blank,
-      });
+  for (let r = 0; r < height + maxColumnHints; r++) {
+    for (let c = 0; c < width + maxRowHints; c++) {
+      if (r < maxColumnHints && c < maxRowHints) {
+        grid.push({ type: GridItemType.Empty });
+      } else if (r < maxColumnHints) {
+        const columnIndex = c - maxRowHints;
+        const columnHint = columnHints[columnIndex] || [];
+        const hintIndex = r - (maxColumnHints - columnHint.length);
+        const hintValue =
+          columnIndex >= 0 && hintIndex >= 0
+            ? columnHint[hintIndex]
+            : undefined;
+
+        grid.push(
+          hintValue !== undefined
+            ? { type: GridItemType.Clue, hintValue }
+            : { type: GridItemType.Empty },
+        );
+      } else if (c < maxRowHints) {
+        const rowIndex = r - maxColumnHints;
+        const rowHint = rowHints[rowIndex] || [];
+        const hintIndex = c - (maxRowHints - rowHint.length);
+        const hintValue =
+          rowIndex >= 0 && hintIndex >= 0 ? rowHint[hintIndex] : undefined;
+
+        grid.push(
+          hintValue !== undefined
+            ? { type: GridItemType.Clue, hintValue }
+            : { type: GridItemType.Empty },
+        );
+      } else {
+        const rowIndex = r - maxColumnHints;
+        const columnIndex = c - maxRowHints;
+
+        grid.push({
+          type: GridItemType.Cell,
+          rowIndex,
+          colIndex: columnIndex,
+          cellState: CellState.Blank,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
- Storing hints in a separate table, to reduce FE logic required to render grids. 
- Fixes support for grids where number of columns and is are not equal.
- Fixes navigation from the packs page to the selected nonogram